### PR TITLE
Add Dream Unlimited voice-driven stopwatch experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# Stopwatch
-a stop watch app for my macbook 
+# Dream Unlimited Stopwatch
+
+A spiritual, modern stopwatch that responds to your voice to capture "clipped" moments and saves your session timeline automatically when you close out.
+
+## Features
+- 🌌 **Immersive interface:** Aurora-inspired glassmorphism with light/dark toggle.
+- 🕒 **Precision timing:** Start, pause/resume, reset, and manual clip controls.
+- 🗣️ **Voice mantra control:** Define your own clip word and completion phrase. Speak the mantra to capture a lap, or say the completion phrase (default: “session complete”) to end and save the journey.
+- 📄 **Automatic session export:** When a session completes, a JSON file with all lap data is downloaded (Chrome/Edge will place this in your default download folder—move it to Desktop to match your ritual).
+
+## Getting Started
+1. Open `index.html` in a modern Chromium-based browser (Chrome, Edge, Arc, Brave) for Web Speech API support.
+2. Grant microphone access when prompted.
+3. Set the session name, clip word, and completion phrase to whatever inspires you.
+4. Press **Start** to begin tracking.
+5. Speak your clip word or press **Clip** to capture moments.
+6. Say your completion phrase (or press **Export**) to download the session record.
+
+> Tip: If voice capture stops listening, tap the microphone button again to resume. The Web Speech API may occasionally stop after periods of silence.
+
+## Data Format
+The exported JSON contains:
+- `sessionName`
+- `startedAt` and `completedAt` timestamps (ISO 8601)
+- `clipWord`, `completionPhrase`
+- `totalElapsed`
+- `laps`: array of lap objects (`index`, `time`, `delta`, `origin`, `spokenPhrase`)
+
+## Development
+No build step required—simply edit the HTML, CSS, and JavaScript files. For changes to voice behavior, update `script.js`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dream Unlimited Stopwatch</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div class="cosmic-glow"></div>
+  <main class="app-card">
+    <header class="app-header">
+      <div>
+        <h1>Dream Unlimited</h1>
+        <p class="tagline">Spiritual stopwatch for transcendent sessions</p>
+      </div>
+      <button id="themeToggle" class="icon-button" aria-label="Toggle aurora">
+        <span class="icon">✨</span>
+      </button>
+    </header>
+
+    <section class="session-config" aria-label="Session configuration">
+      <div class="input-group">
+        <label for="sessionName">Session name</label>
+        <input type="text" id="sessionName" placeholder="e.g. Breathwork Journey" />
+      </div>
+      <div class="input-group">
+        <label for="clipWord">Clip word</label>
+        <input type="text" id="clipWord" placeholder="e.g. illuminate" />
+      </div>
+      <div class="input-group">
+        <label for="completePhrase">Completion phrase</label>
+        <input type="text" id="completePhrase" placeholder="e.g. session complete" />
+      </div>
+    </section>
+
+    <section class="stopwatch" aria-label="Stopwatch controls">
+      <div class="time-display" id="timeDisplay">00:00:00.000</div>
+      <div class="controls">
+        <button id="startPause" class="primary">Start</button>
+        <button id="reset" class="secondary" disabled>Reset</button>
+        <button id="clip" class="secondary" disabled>Clip</button>
+      </div>
+      <div class="voice-status" id="voiceStatus">🎙️ Voice idle</div>
+      <button id="voiceToggle" class="voice-button" aria-pressed="false">
+        <span class="icon">🎤</span>
+        <span class="label">Activate voice listener</span>
+      </button>
+    </section>
+
+    <section class="laps" aria-label="Clipped times">
+      <div class="laps-header">
+        <h2>Clipped Moments</h2>
+        <button id="export" class="secondary" disabled>Export</button>
+      </div>
+      <ul id="lapsList" class="laps-list"></ul>
+    </section>
+
+    <footer class="app-footer">
+      <p>
+        Speak your chosen <strong>clip word</strong> to capture a moment. Speak the
+        <strong>completion phrase</strong> to end the session and download the journey.
+      </p>
+      <p class="supporting">Best experienced in Chrome or Edge with the microphone permitted.</p>
+    </footer>
+  </main>
+
+  <template id="lapTemplate">
+    <li class="lap-item">
+      <span class="lap-index"></span>
+      <span class="lap-time"></span>
+      <span class="lap-diff"></span>
+    </li>
+  </template>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,287 @@
+const timeDisplay = document.getElementById('timeDisplay');
+const startPauseBtn = document.getElementById('startPause');
+const resetBtn = document.getElementById('reset');
+const clipBtn = document.getElementById('clip');
+const lapsList = document.getElementById('lapsList');
+const lapTemplate = document.getElementById('lapTemplate');
+const exportBtn = document.getElementById('export');
+const voiceToggle = document.getElementById('voiceToggle');
+const voiceStatus = document.getElementById('voiceStatus');
+const themeToggle = document.getElementById('themeToggle');
+
+const sessionNameInput = document.getElementById('sessionName');
+const clipWordInput = document.getElementById('clipWord');
+const completePhraseInput = document.getElementById('completePhrase');
+
+let startTimestamp = null;
+let elapsed = 0;
+let rafId = null;
+let running = false;
+let laps = [];
+let recognition = null;
+let voiceActive = false;
+let voiceAvailable = 'SpeechRecognition' in window || 'webkitSpeechRecognition' in window;
+let lastRecognized = '';
+
+const formatTime = (ms) => {
+  const milliseconds = Math.floor(ms % 1000);
+  const totalSeconds = Math.floor(ms / 1000);
+  const seconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const hours = Math.floor(totalMinutes / 60);
+
+  return [hours, minutes, seconds]
+    .map((unit) => unit.toString().padStart(2, '0'))
+    .join(':')
+    .concat('.', milliseconds.toString().padStart(3, '0'));
+};
+
+const renderLaps = () => {
+  lapsList.innerHTML = '';
+  laps.forEach((lap, index) => {
+    const node = lapTemplate.content.cloneNode(true);
+    node.querySelector('.lap-index').textContent = `#${index + 1}`;
+    node.querySelector('.lap-time').textContent = lap.display;
+    node.querySelector('.lap-diff').textContent = index === 0 ? '—' : `+${lap.delta}`;
+    lapsList.appendChild(node);
+  });
+};
+
+const updateButtons = () => {
+  clipBtn.disabled = !running;
+  resetBtn.disabled = running || (!running && elapsed === 0 && laps.length === 0);
+  exportBtn.disabled = laps.length === 0;
+};
+
+const updateTime = () => {
+  if (!running) return;
+  const now = performance.now();
+  const diff = now - startTimestamp;
+  timeDisplay.textContent = formatTime(elapsed + diff);
+  rafId = requestAnimationFrame(updateTime);
+};
+
+const start = () => {
+  if (running) return;
+  startTimestamp = performance.now();
+  running = true;
+  startPauseBtn.textContent = 'Pause';
+  startPauseBtn.classList.add('active');
+  updateButtons();
+  rafId = requestAnimationFrame(updateTime);
+};
+
+const pause = () => {
+  if (!running) return;
+  running = false;
+  cancelAnimationFrame(rafId);
+  const now = performance.now();
+  elapsed += now - startTimestamp;
+  startPauseBtn.textContent = 'Resume';
+  startPauseBtn.classList.remove('active');
+  updateButtons();
+};
+
+const reset = () => {
+  running = false;
+  cancelAnimationFrame(rafId);
+  elapsed = 0;
+  laps = [];
+  startTimestamp = null;
+  timeDisplay.textContent = formatTime(0);
+  startPauseBtn.textContent = 'Start';
+  updateButtons();
+  renderLaps();
+};
+
+const clipLap = (origin = 'manual') => {
+  if (!running) return;
+  const now = performance.now();
+  const total = elapsed + (now - startTimestamp);
+  const display = formatTime(total);
+  const delta = laps.length === 0 ? 0 : total - laps[laps.length - 1].total;
+
+  laps.push({
+    total,
+    display,
+    delta: formatTime(delta).slice(-8),
+    origin,
+    spoken: lastRecognized,
+  });
+  renderLaps();
+  exportBtn.disabled = false;
+};
+
+const exportSession = () => {
+  if (!laps.length) return;
+  const sessionName = sessionNameInput.value.trim() || 'Dream-Unlimited-Session';
+  const totalElapsedMs = running ? elapsed + (performance.now() - startTimestamp) : elapsed;
+  const data = {
+    sessionName,
+    startedAt: new Date(Date.now() - totalElapsedMs).toISOString(),
+    completedAt: new Date().toISOString(),
+    clipWord: clipWordInput.value.trim() || null,
+    completionPhrase: completePhraseInput.value.trim() || null,
+    totalElapsed: formatTime(totalElapsedMs),
+    laps: laps.map((lap, index) => ({
+      index: index + 1,
+      time: lap.display,
+      delta: lap.delta,
+      origin: lap.origin,
+      spokenPhrase: lap.spoken,
+    })),
+  };
+
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const filename = `${sessionName.replace(/[^a-z0-9\-]+/gi, '-')}--${
+    new Date().toISOString().replace(/[:.]/g, '-')
+  }.json`;
+
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+};
+
+const completeSession = () => {
+  pause();
+  exportSession();
+  voiceStatus.textContent = '✨ Session saved. Ready for another journey.';
+};
+
+const toggleTheme = () => {
+  document.body.classList.toggle('light');
+};
+
+themeToggle.addEventListener('click', toggleTheme);
+
+startPauseBtn.addEventListener('click', () => {
+  if (running) {
+    pause();
+  } else {
+    start();
+  }
+});
+
+resetBtn.addEventListener('click', reset);
+clipBtn.addEventListener('click', () => clipLap('manual'));
+exportBtn.addEventListener('click', exportSession);
+
+const stopVoice = () => {
+  if (recognition && voiceActive) {
+    recognition.stop();
+    voiceActive = false;
+    voiceToggle.setAttribute('aria-pressed', 'false');
+    voiceToggle.querySelector('.label').textContent = 'Activate voice listener';
+    voiceStatus.textContent = '🎙️ Voice idle';
+  }
+};
+
+const handleRecognitionResult = (event) => {
+  for (const result of event.results) {
+    if (!result.isFinal) continue;
+    const transcript = result[0].transcript.trim().toLowerCase();
+    lastRecognized = transcript;
+    const clipWord = clipWordInput.value.trim().toLowerCase();
+    const completionPhrase = completePhraseInput.value.trim().toLowerCase() || 'session complete';
+
+    if (clipWord && transcript.includes(clipWord)) {
+      clipLap('voice');
+      voiceStatus.textContent = `🔮 Heard "${clipWord}" — moment captured!`;
+      continue;
+    }
+
+    if (transcript.includes(completionPhrase)) {
+      voiceStatus.textContent = '🌙 Session ending — saving your journey...';
+      completeSession();
+      stopVoice();
+      break;
+    }
+
+    if (transcript.includes('start')) {
+      start();
+      voiceStatus.textContent = '🚀 Launching the flow';
+      continue;
+    }
+
+    if (transcript.includes('pause') || transcript.includes('stop')) {
+      pause();
+      voiceStatus.textContent = '⏸️ Flow paused';
+      continue;
+    }
+  }
+};
+
+const initVoice = () => {
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!SpeechRecognition) {
+    voiceStatus.textContent = '⚠️ Voice capture not supported in this browser.';
+    voiceToggle.disabled = true;
+    return;
+  }
+
+  recognition = new SpeechRecognition();
+  recognition.lang = 'en-US';
+  recognition.continuous = true;
+  recognition.interimResults = true;
+  recognition.maxAlternatives = 1;
+
+  recognition.addEventListener('start', () => {
+    voiceActive = true;
+    voiceToggle.setAttribute('aria-pressed', 'true');
+    voiceToggle.querySelector('.label').textContent = 'Listening — speak your mantra';
+    voiceStatus.textContent = '🎧 Listening for your command mantra...';
+  });
+
+  recognition.addEventListener('end', () => {
+    voiceActive = false;
+    voiceToggle.setAttribute('aria-pressed', 'false');
+    voiceToggle.querySelector('.label').textContent = 'Activate voice listener';
+    if (voiceAvailable) {
+      voiceStatus.textContent = '🎙️ Voice idle';
+    }
+  });
+
+  recognition.addEventListener('error', (event) => {
+    voiceStatus.textContent = `⚠️ Voice error: ${event.error}`;
+  });
+
+  recognition.addEventListener('result', handleRecognitionResult);
+};
+
+voiceToggle.addEventListener('click', () => {
+  if (!recognition) {
+    initVoice();
+  }
+
+  if (!recognition) return;
+
+  if (voiceActive) {
+    recognition.stop();
+  } else {
+    try {
+      recognition.start();
+    } catch (error) {
+      voiceStatus.textContent = `⚠️ Voice could not start: ${error.message}`;
+    }
+  }
+});
+
+window.addEventListener('beforeunload', () => {
+  if (voiceActive && recognition) {
+    recognition.stop();
+  }
+});
+
+// Provide default phrases for quick start
+clipWordInput.value = 'illuminate';
+completePhraseInput.value = 'session complete';
+sessionNameInput.value = 'Dream Unlimited Session';
+
+updateButtons();
+renderLaps();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,314 @@
+:root {
+  color-scheme: dark light;
+  --aurora-bg: radial-gradient(circle at top, rgba(152, 93, 255, 0.4), rgba(22, 8, 69, 0.9));
+  --surface: rgba(15, 12, 34, 0.8);
+  --surface-light: rgba(255, 255, 255, 0.1);
+  --text-primary: #f8f7ff;
+  --text-secondary: rgba(248, 247, 255, 0.7);
+  --accent: #8f7bff;
+  --accent-strong: #c39bff;
+  --success: #7ef3c3;
+  --danger: #ff8f8f;
+  --shadow: 0 20px 60px rgba(10, 6, 35, 0.4);
+}
+
+body.light {
+  --aurora-bg: radial-gradient(circle at top, rgba(219, 237, 255, 0.9), rgba(222, 199, 255, 0.6));
+  --surface: rgba(255, 255, 255, 0.7);
+  --surface-light: rgba(255, 255, 255, 0.35);
+  --text-primary: #1a1333;
+  --text-secondary: rgba(26, 19, 51, 0.65);
+  --accent: #5d4bff;
+  --accent-strong: #7c63ff;
+  --success: #16a085;
+  --danger: #c0392b;
+  --shadow: 0 25px 70px rgba(48, 22, 121, 0.25);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #05010f;
+  background-image: var(--aurora-bg);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem;
+  position: relative;
+  overflow: hidden;
+  transition: background-image 0.6s ease, color 0.6s ease;
+}
+
+.cosmic-glow {
+  position: absolute;
+  width: 80vw;
+  height: 80vw;
+  max-width: 1100px;
+  max-height: 1100px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.15) 0%, rgba(15, 12, 34, 0) 65%);
+  filter: blur(60px);
+  pointer-events: none;
+  animation: pulse 18s ease-in-out infinite;
+  transform: translateY(-20%);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: translateY(-20%) scale(1);
+  }
+  50% {
+    opacity: 0.9;
+    transform: translateY(-15%) scale(1.08);
+  }
+}
+
+.app-card {
+  position: relative;
+  width: min(720px, 100%);
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 2.8rem;
+  backdrop-filter: blur(24px) saturate(130%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 4vw, 3rem);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.tagline {
+  margin-top: 0.35rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+}
+
+.icon-button {
+  background: var(--surface-light);
+  border: none;
+  color: var(--accent-strong);
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.icon-button:hover {
+  transform: translateY(-2px) scale(1.05);
+}
+
+.session-config {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.4rem;
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+label {
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+input {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid transparent;
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: border 0.3s ease, background 0.3s ease;
+}
+
+input:focus {
+  outline: none;
+  border: 1px solid var(--accent);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.stopwatch {
+  display: grid;
+  gap: 1.4rem;
+}
+
+.time-display {
+  font-size: clamp(2.4rem, 5vw, 3.6rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  text-align: center;
+  letter-spacing: 0.08em;
+}
+
+.controls {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+button.primary,
+button.secondary,
+.voice-button {
+  border: none;
+  border-radius: 16px;
+  padding: 0.85rem 1.6rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.25s ease, filter 0.25s ease, background 0.25s ease;
+  letter-spacing: 0.03em;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(135, 114, 255, 0.35);
+}
+
+button.primary:disabled {
+  background: rgba(255, 255, 255, 0.25);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: var(--surface-light);
+  color: var(--text-primary);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-2px);
+  filter: brightness(1.05);
+}
+
+.voice-button {
+  background: rgba(255, 255, 255, 0.14);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  color: var(--text-primary);
+}
+
+.voice-button[aria-pressed='true'] {
+  background: rgba(126, 243, 195, 0.2);
+  color: var(--success);
+  box-shadow: 0 15px 30px rgba(126, 243, 195, 0.35);
+}
+
+.voice-status {
+  text-align: center;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.laps {
+  display: grid;
+  gap: 1rem;
+}
+
+.laps-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.laps-header h2 {
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.laps-list {
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+  max-height: 220px;
+  overflow-y: auto;
+  padding-right: 0.2rem;
+}
+
+.lap-item {
+  display: grid;
+  grid-template-columns: minmax(70px, 0.8fr) 1fr minmax(120px, 1fr);
+  gap: 0.8rem;
+  padding: 0.9rem 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  font-variant-numeric: tabular-nums;
+}
+
+.lap-index {
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.lap-diff {
+  text-align: right;
+  color: var(--text-secondary);
+}
+
+.app-footer {
+  text-align: center;
+  color: var(--text-secondary);
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.92rem;
+}
+
+.supporting {
+  font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1.6rem;
+  }
+
+  .app-card {
+    padding: 2rem;
+  }
+
+  .lap-item {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .lap-diff {
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Dream Unlimited stopwatch interface with aurora-inspired styling and manual controls
- integrate Web Speech API commands to clip laps and finish sessions hands-free
- export session data as downloadable JSON and document setup and usage details

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e31856bbd88327acd404e8c081fc18